### PR TITLE
Updating React Native Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "react-native": "^0.41.2",
+    "react-native": "*",
     "react-native-windows": "0.41.0-rc.1"
   },
   "repository": {


### PR DESCRIPTION
Per the following article, peer dependency evaluation is failing:

https://michaelsoolee.com/npm-pre-1-caret-rules/

Looks like setting the dependency requirement using a caret only works on versions that are 1.0.0 and above.