### PR TITLE
Update react-native-windows dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react-native": "*",
-    "react-native-windows": "0.41.0-rc.1"
+    "react-native-windows": "*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I am not direct using `react-native-windows`, but when doing the install with latest npm it is generating this error:

```
npm ERR! Could not resolve dependency:
npm ERR! peer react@"~15.4.0" from react-native-windows@0.41.0-rc.1
npm ERR! node_modules/react-native-windows
npm ERR!   peer react-native-windows@"0.41.0-rc.1" from react-native-heic-converter@1.3.1
npm ERR!   node_modules/react-native-heic-converter
npm ERR!     react-native-heic-converter@"^1.3.0" from the root project

```