### PR TITLE
Update react-native-windows to optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
     "react-native": "*",
     "react-native-windows": "*"
   },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/maxim-kolesnikov/react-native-heic-converter"


### PR DESCRIPTION
Thanks for creating such a useful library.

`react-native-windows` is not essential for most react-native projects, and doesn't seem to be related to the behavior of `react-native-heic-converter`.

Sadly, `react-native-heic-converter` is the only library that makes me install `react-native-windows` in my project, and the several other libraries have been setting `react-native-windows` as an optional peer dependency.

Please merge this change and release it to npm.
Thank you.
